### PR TITLE
Default to using the host specified to serverless-offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ plugins:
   - serverless-offline-sns
 ```
 
-Configure the plugin with your offline SNS endpoint and a free port the plugin can use.
+Configure the plugin with your offline SNS endpoint, host to listen on, and a free port the plugin can use.
 ```YAML
 custom:
   serverless-offline-sns:
     port: 4002 # a free port for the sns server to run on
     debug: false
+    # host: 0.0.0.0 # Optional, defaults to 127.0.0.1. Useful for Docker on OSX
     # sns-endpoint: http://127.0.0.1:4567 # Optional. Only if you want to use a custom endpoint
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ plugins:
 ```
 
 Configure the plugin with your offline SNS endpoint, host to listen on, and a free port the plugin can use.
+
 ```YAML
 custom:
   serverless-offline-sns:
@@ -45,6 +46,8 @@ custom:
     # host: 0.0.0.0 # Optional, defaults to 127.0.0.1. Useful for Docker on OSX
     # sns-endpoint: http://127.0.0.1:4567 # Optional. Only if you want to use a custom endpoint
 ```
+
+If setting the *host* parameter as above, follow best security practice and ensure that your port is only visible to trusted programs. If using Docker on OSX, this will be the case in most circumstances.
 
 If you are using the [serverless-offline](https://github.com/dherault/serverless-offline) plugin serverless-offline-sns will start automatically. If you are not using this plugin you can run the following command instead:
 ```bash

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ custom:
   serverless-offline-sns:
     port: 4002 # a free port for the sns server to run on
     debug: false
-    # host: 0.0.0.0 # Optional, defaults to 127.0.0.1. Useful for Docker on OSX
+    # host: 0.0.0.0 # Optional, defaults to 127.0.0.1 if not provided to serverless-offline
     # sns-endpoint: http://127.0.0.1:4567 # Optional. Only if you want to use a custom endpoint
 ```
 
-If setting the *host* parameter as above, follow best security practice and ensure that your port is only visible to trusted programs. If using Docker on OSX, this will be the case in most circumstances.
+In normal operation, if the *--host* option is provided when starting serverless-offline, then the plugin will also use that host. The *host* parameter as shown above may be provided to override this behavior.
+
+If running under Docker on OSX, the *--host* option to serverless-offline should be set to the "any" host (0.0.0.0), as open ports on the container are not routed internally to 127.0.0.1 (localhost). This is generally safe, as open container ports are only visible to the host system via localhost.
 
 If you are using the [serverless-offline](https://github.com/dherault/serverless-offline) plugin serverless-offline-sns will start automatically. If you are not using this plugin you can run the following command instead:
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "watch": "tsc -p src -w",
     "test": "nyc ts-mocha \"test/**/*.ts\" -p src/",
     "lint": "tslint -p src/",
-    "prepare": "npm run lint && npm run test && npm run build"
+    "prepare": "npm run lint && npm run test && npm run build",
+    "postinstall": "postinstall-build dist"
   },
   "repository": {
     "type": "git",
@@ -34,9 +35,10 @@
     "aws-sdk": "^2.41.0",
     "body-parser": "^1.18.2",
     "express": "^4.15.4",
+    "node-fetch": "^1.7.3",
+    "postinstall-build": "^5.0.1",
     "uuid": "^3.1.0",
-    "xml": "^1.0.1",
-    "node-fetch": "^1.7.3"
+    "xml": "^1.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "watch": "tsc -p src -w",
     "test": "nyc ts-mocha \"test/**/*.ts\" -p src/",
     "lint": "tslint -p src/",
-    "prepare": "npm run lint && npm run test && npm run build",
-    "postinstall": "postinstall-build dist"
+    "prepare": "npm run lint && npm run test && npm run build"
   },
   "repository": {
     "type": "git",
@@ -36,7 +35,6 @@
     "body-parser": "^1.18.2",
     "express": "^4.15.4",
     "node-fetch": "^1.7.3",
-    "postinstall-build": "^5.0.1",
     "uuid": "^3.1.0",
     "xml": "^1.0.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,9 @@ class ServerlessOfflineSns {
         if (this.config.host) {
             this.debug(`using specified host ${this.config.host}`);
             host = this.config.host;
+        } else if (this.options.host) {
+            this.debug(`using offline specified host ${this.options.host}`);
+            host = this.options.host;
         }
         return new Promise(res => {
             this.server = this.app.listen(this.port, host, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ class ServerlessOfflineSns {
 
     public async listen() {
         this.debug("starting plugin");
-        let host = '127.0.0.1';
+        let host = "127.0.0.1";
         if (this.config.host) {
             this.debug(`using specified host ${this.config.host}`);
             host = this.config.host;

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,9 +135,14 @@ class ServerlessOfflineSns {
 
     public async listen() {
         this.debug("starting plugin");
+        let host = '127.0.0.1';
+        if (this.config.host) {
+            this.debug(`using specified host ${this.config.host}`);
+            host = this.config.host;
+        }
         return new Promise(res => {
-            this.server = this.app.listen(this.port, "127.0.0.1", () => {
-                this.debug(`listening on 127.0.0.1:${this.port}`);
+            this.server = this.app.listen(this.port, host, () => {
+                this.debug(`listening on ${host}:${this.port}`);
                 res();
             });
         });


### PR DESCRIPTION
Matthew - take a look. I think this is the cleanest way to do it. I've updated the README to match.
