### PR TITLE
Pass full function object to SNS adapter so timeout is set correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,9 +123,9 @@ class ServerlessOfflineSns {
             }
             const data = await this.snsAdapter.createTopic(topicName);
             this.debug("topic: " + JSON.stringify(data));
-            await this.snsAdapter.subscribe(fnName, () => this.createHandler(fn), data.TopicArn);
+            await this.snsAdapter.subscribe(fn, () => this.createHandler(fn), data.TopicArn);
         } else if (typeof snsConfig.arn === "string") {
-            await this.snsAdapter.subscribe(fnName, () => this.createHandler(fn), snsConfig.arn);
+            await this.snsAdapter.subscribe(fn, () => this.createHandler(fn), snsConfig.arn);
         } else {
             this.log("unsupported config: " + snsConfig);
             return Promise.resolve("unsupported config: " + snsConfig);

--- a/src/sns-adapter.ts
+++ b/src/sns-adapter.ts
@@ -77,13 +77,13 @@ export class SNSAdapter implements ISNSAdapter {
         }));
     }
 
-    public async subscribe(fnName, getHandler, arn) {
-        const subscribeEndpoint = "http://127.0.0.1:" + this.port + "/" + fnName;
-        this.debug("subscribe: " + fnName + " " + arn);
+    public async subscribe(fn, getHandler, arn) {
+        const subscribeEndpoint = "http://127.0.0.1:" + this.port + "/" + fn.name;
+        this.debug("subscribe: " + fn.name + " " + arn);
         this.debug("subscribeEndpoint: " + subscribeEndpoint);
-        this.app.post("/" + fnName, (req, res) => {
-            this.debug("calling fn: " + fnName + " 1");
-            getHandler()(req.body, this.createLambdaContext({name: fnName}), (data) => {
+        this.app.post("/" + fn.name, (req, res) => {
+            this.debug("calling fn: " + fn.name + " 1");
+            getHandler()(req.body, this.createLambdaContext(fn), (data) => {
                 res.send(data);
             });
         });
@@ -98,7 +98,7 @@ export class SNSAdapter implements ISNSAdapter {
                 if (err) {
                     this.debug(err, err.stack);
                 } else {
-                    this.debug(`successfully subscribed fn "${fnName}" to topic: "${arn}"`);
+                    this.debug(`successfully subscribed fn "${fn.name}" to topic: "${arn}"`);
                 }
                 res();
             });


### PR DESCRIPTION
Timeouts configured in the serverless.yml file weren't being respected, since the SNS subscription was just passing the function name to the adapter (instead of the whole serverless function object). This resulted in timeouts being set to the default value of 6 seconds.