### PR TITLE
add possibility to receive MessageAttributes 

### DIFF
--- a/src/sns-adapter.ts
+++ b/src/sns-adapter.ts
@@ -1,5 +1,5 @@
 import * as AWS from "aws-sdk";
-import { ListSubscriptionsResponse, CreateTopicResponse } from "aws-sdk/clients/sns.d";
+import { ListSubscriptionsResponse, CreateTopicResponse, MessageAttributeMap } from "aws-sdk/clients/sns.d";
 import { ISNSAdapter, IDebug } from "./types";
 import fetch from "node-fetch";
 
@@ -105,11 +105,12 @@ export class SNSAdapter implements ISNSAdapter {
         });
     }
 
-    public async publish(topicArn: string, message: string, type: string = "json") {
+    public async publish(topicArn: string, message: string, type: string = "json", messageAttributes: MessageAttributeMap = {}) {
         await new Promise(res => this.sns.publish({
             Message: message,
             MessageStructure: type,
             TopicArn: topicArn,
+            MessageAttributes: messageAttributes,
         }, res));
     }
 

--- a/test/mock/handler.ts
+++ b/test/mock/handler.ts
@@ -1,8 +1,12 @@
 let nPongs = 0;
+let event;
 
 export const getPongs = () => nPongs;
 export const resetPongs = () => nPongs = 0;
-export const pongHandler = (event, ctx, cb) => {
+export const getEvent = () => event;
+export const resetEvent = () => event = undefined;
+export const pongHandler = (evt, ctx, cb) => {
     nPongs += 1;
+    event = evt;
     cb("{}");
 };


### PR DESCRIPTION
Currently any `MessageAttributes` will be swallowed.

This change will send the `MessageAttributes` along with the message in the same format as AWS does.

It is only possible to pass `MessageAttributes` when the `MessageStructure==='raw'`, otherwise an empty object will be returned (current default).