### PR TITLE
MessageAttribute can work if MessageStructure !== 'json'

### DIFF
--- a/src/sns-server.ts
+++ b/src/sns-server.ts
@@ -30,10 +30,6 @@ const arrayify = obj => {
 };
 
 const parseMessageAttributes = body => {
-    if (body.MessageStructure !== "raw") {
-        return {};
-    }
-
     const entries = Object.keys(body)
         .filter(key => key.startsWith("MessageAttributes.entry"))
         .reduce(

--- a/src/sns-server.ts
+++ b/src/sns-server.ts
@@ -30,6 +30,10 @@ const arrayify = obj => {
 };
 
 const parseMessageAttributes = body => {
+    if (body.MessageStructure === "json") {
+        return {};
+    }
+
     const entries = Object.keys(body)
         .filter(key => key.startsWith("MessageAttributes.entry"))
         .reduce(


### PR DESCRIPTION
In v0.30.0, it's only pass MessageAttribute into lambda when MessageStructure == 'raw'.
By AWS SNS developer guide, Using Amazon SNS Message Attributes, MessageStructure should be raw delivery to use MessageAttribute with SQS endpoints.
And by AWS:SNS API document, valid value of MessageStructure is 'json'. Otherwise it will be raw delivery.
So we can block MessageAttrubite passthrough only when MessageStructure !== 'json'. The behavior of simulator will more similar with production env in AWS.
