### PR TITLE
 Adding a fix for Psuedo params

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ custom:
     debug: false
     # host: 0.0.0.0 # Optional, defaults to 127.0.0.1 if not provided to serverless-offline
     # sns-endpoint: http://127.0.0.1:4567 # Optional. Only if you want to use a custom endpoint
+    # accountId: 123456789012 # Optional
 ```
 
 In normal operation, the plugin will use the same *--host* option as provided to serverless-offline. The *host* parameter as shown above overrides this setting.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-sns",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-sns",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Serverless plugin to run a local SNS server and call lambdas with events notifications.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ class ServerlessOfflineSns {
     private options: any;
     private location: string;
     private region: string;
+    private accountId: string;
 
     constructor(serverless: any, options: any) {
         this.app = express();
@@ -55,6 +56,7 @@ class ServerlessOfflineSns {
         process.env = _.extend({}, this.serverless.service.provider.environment, process.env);
         this.config = this.serverless.service.custom["serverless-offline-sns"] || {};
         this.port = this.config.port || 4002;
+        this.accountId = this.config.accountId || "123456789012";
         const offlineConfig = this.serverless.service.custom["serverless-offline"] || {};
         this.location = process.cwd();
         if (offlineConfig.location) {
@@ -87,11 +89,11 @@ class ServerlessOfflineSns {
     }
 
     public async serve() {
-        this.snsServer = new SNSServer((msg, ctx) => this.debug(msg, ctx), this.app, this.region);
+        this.snsServer = new SNSServer((msg, ctx) => this.debug(msg, ctx), this.app, this.region, this.accountId);
     }
 
     public async subscribeAll() {
-        this.snsAdapter = new SNSAdapter(this.port, this.serverless.service.provider.region, this.config["sns-endpoint"], (msg, ctx) => this.debug(msg, ctx), this.app, this.serverless.service.service, this.serverless.service.provider.stage);
+        this.snsAdapter = new SNSAdapter(this.port, this.serverless.service.provider.region, this.config["sns-endpoint"], (msg, ctx) => this.debug(msg, ctx), this.app, this.serverless.service.service, this.serverless.service.provider.stage, this.accountId);
         await this.unsubscribeAll();
         this.debug("subscribing");
         await Promise.all(Object.keys(this.serverless.service.functions).map(fnName => {

--- a/test/mock/handler.ts
+++ b/test/mock/handler.ts
@@ -18,3 +18,8 @@ export const envHandler = (evt, ctx, cb) => {
     result = process.env["MY_VAR"];
     cb("{}");
 };
+
+export const psuedoHandler = (evt, ctx, cb) => {
+    result = evt.Records[0].Sns.TopicArn;
+    cb("{}");
+};


### PR DESCRIPTION
When using this plugin: https://www.npmjs.com/package/serverless-pseudo-parameters
None of the account information is being replace for account id. Psudeo params manages replace at the package level which never takes place offline.
This functionality replaces the psuedo param #{AWS::AccountId} with a customizable account id so you could ensure expected account id behavior.