### PR TITLE
Uses config host for subscriber urls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,17 @@ class ServerlessOfflineSns {
     }
 
     public async subscribeAll() {
-        this.snsAdapter = new SNSAdapter(this.port, this.serverless.service.provider.region, this.config["sns-endpoint"], (msg, ctx) => this.debug(msg, ctx), this.app, this.serverless.service.service, this.serverless.service.provider.stage, this.accountId);
+        this.snsAdapter = new SNSAdapter(
+            this.port,
+            this.serverless.service.provider.region,
+            this.config["sns-endpoint"],
+            (msg, ctx) => this.debug(msg, ctx),
+            this.app,
+            this.serverless.service.service,
+            this.serverless.service.provider.stage,
+            this.accountId,
+            this.config.host,
+        );
         await this.unsubscribeAll();
         this.debug("subscribing");
         await Promise.all(Object.keys(this.serverless.service.functions).map(fnName => {

--- a/src/sns-adapter.ts
+++ b/src/sns-adapter.ts
@@ -16,13 +16,13 @@ export class SNSAdapter implements ISNSAdapter {
     private adapterEndpoint: string;
     private accountId: string;
 
-    constructor(port, region, snsEndpoint, debug, app, serviceName, stage, accountId) {
+    constructor(port, region, snsEndpoint, debug, app, serviceName, stage, accountId, host) {
         this.pluginDebug = debug;
         this.port = port;
         this.app = app;
         this.serviceName = serviceName;
         this.stage = stage;
-        this.adapterEndpoint = `http://127.0.0.1:${port}`;
+        this.adapterEndpoint = `http://${host || "127.0.0.1"}:${port}`;
         this.endpoint = snsEndpoint || `http://127.0.0.1:${port}`;
         this.debug("using endpoint: " + this.endpoint);
         this.accountId = accountId;


### PR DESCRIPTION
This PR would ensure that the `host` config option is used for the generated subscription urls.  Currently, this was only listening on the provided `host` but still using the default of `127.0.0.1` as the subscription url - which would cause the push to the subscription url to fail.

I believe this was actually the issue being reported in #23 . This is specifically necessary for me to support use in a docker compose setup where localstack is providing SNS. I need to ensure the host of the lambda container is being used for subscription urls.

Open question: Should this also attempt to fall back to `this.options.host`, to default to use the serverless-offline host if set?