### PR TITLE
Make sure publish() endpoint will return a valid PublishResponse

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -52,7 +52,7 @@ export function parseMessageAttributes(body) {
         );
 }
 
-export function createSnsEvent(topicArn, subscriptionArn, subject, message, messageAttributes?) {
+export function createSnsEvent(topicArn, subscriptionArn, subject, message, messageId, messageAttributes?) {
     return {
         Records: [
             {
@@ -64,7 +64,7 @@ export function createSnsEvent(topicArn, subscriptionArn, subject, message, mess
                     Timestamp: new Date().toISOString(),
                     Signature: "EXAMPLE",
                     SigningCertUrl: "EXAMPLE",
-                    MessageId: uuid(),
+                    MessageId: messageId,
                     Message: message,
                     MessageAttributes: messageAttributes || {},
                     Type: "Notification",
@@ -75,4 +75,8 @@ export function createSnsEvent(topicArn, subscriptionArn, subject, message, mess
             },
         ],
     };
+}
+
+export function createMessageId() {
+    return uuid();
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-import {ListSubscriptionsResponse, CreateTopicResponse} from "aws-sdk/clients/sns.d";
+import {ListSubscriptionsResponse, CreateTopicResponse, PublishResponse} from "aws-sdk/clients/sns.d";
 
 export type IDebug = (msg: any, stack?: any) => void;
 
@@ -9,7 +9,7 @@ export interface ISNSAdapter {
     unsubscribe(arn: string): Promise<void>;
     createTopic(topicName: string): Promise<CreateTopicResponse>;
     subscribe(fnName: string, handler: SLSHandler, arn: string): Promise<void>;
-    publish(topicArn: string, type: string, message: string): Promise<void>;
+    publish(topicArn: string, type: string, message: string): Promise<PublishResponse>;
 }
 export interface ISNSAdapterConstructable {
     new(endpoint: string, port: number, region: string, debug: IDebug): ISNSAdapter;

--- a/test/spec/sns.ts
+++ b/test/spec/sns.ts
@@ -72,6 +72,19 @@ describe("test", () => {
         );
     });
 
+    it("should return a valid response to publish", async () => {
+        plugin = new ServerlessOfflineSns(createServerless(accountId), {});
+        const snsAdapter = await plugin.start();
+        const snsResponse = await snsAdapter.publish(
+            `arn:aws:sns:us-east-1:${accountId}:test-topic`,
+            "'a simple message'"
+        );
+        await new Promise(res => setTimeout(res, 100));
+        expect(snsResponse).to.have.property('ResponseMetadata')
+        expect(snsResponse.ResponseMetadata).to.have.property('RequestId');
+        expect(snsResponse).to.have.property('MessageId');
+    });
+
     it("should error", async () => {
         plugin = new ServerlessOfflineSns(createServerlessBad(accountId), {});
         const snsAdapter = await plugin.start();


### PR DESCRIPTION
This PR adds the missing `MessageId` in `publish()` response.
It's required by some other languages AWS SDK (JavaScript is so forgiving), hence I guess this is might be a good addition.

(I also made sure the type definition will also return a `PublishResponse` as defined in the AWS SDK)