### PR TITLE
fix createHandlers not working for paths with more than one dot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { ISNSAdapter } from "./types";
 import { SNSServer } from "./sns-server";
 import * as _ from "lodash";
 import * as AWS from "aws-sdk";
+import { resolve } from "path";
 
 class ServerlessOfflineSns {
     private config: any;
@@ -159,8 +160,12 @@ class ServerlessOfflineSns {
 
     public createHandler(fn) {
         this.debug(process.cwd());
-        this.debug("require(" + this.location + "/" + fn.handler.split(".")[0] + ")[" + fn.handler.split("/").pop().split(".")[1] + "]");
-        const handler = require(this.location + "/" + fn.handler.split(".")[0])[fn.handler.split("/").pop().split(".")[1]];
+        const handlerFnNameIndex = fn.handler.lastIndexOf(".");
+        const handlerPath = fn.handler.substring(0, handlerFnNameIndex);
+        const handlerFnName = fn.handler.substring(handlerFnNameIndex + 1);
+        const fullHandlerPath = resolve(this.location, handlerPath);
+        this.debug("require(" + fullHandlerPath + ")[" + handlerFnName + "]");
+        const handler = require(fullHandlerPath)[handlerFnName];
         return handler;
     }
 

--- a/test/mock/multi.dot.handler.ts
+++ b/test/mock/multi.dot.handler.ts
@@ -1,0 +1,9 @@
+let hits = 0;
+
+export const resetHits = () => hits = 0;
+export const getHits = () => hits;
+
+export const itsGotDots = (evt, ctx, cb) => {
+    hits += 1;
+    cb("{}");
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "es2015"
+    ]
+  }
+}


### PR DESCRIPTION
fixes handlers in files with more than one dot in the filename not working due to the use of `String.prototype.split` when parsing out the function name from the file name.