### PR TITLE
add [experimental?] support for SQS subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ plugins:
   - serverless-offline-sns
 ```
 
-Note that ordering matters when used with serverless-offline and serverless-webpack. serverless-webpack must be specified at the start of the list of plugins. 
+Note that ordering matters when used with serverless-offline and serverless-webpack. serverless-webpack must be specified at the start of the list of plugins.
 
 Configure the plugin with your offline SNS endpoint, host to listen on, and a free port the plugin can use.
 
@@ -108,6 +108,24 @@ If you use [serverless-offline](https://github.com/dherault/serverless-offline) 
 However if you don't use serverless-offline you can start this plugin manually with -
 ```bash
 serverless offline-sns start
+```
+
+### Subscribing
+
+`serverless-offline-sns` supports `http`, `https`, and `sqs` subscriptions. `email`, `email-json`,
+`sms`, `application`, and `lambda` protocols are not supported at this time.
+
+When using `sqs` the `Endpoint` for the subscription must be the full `QueueUrl` returned from
+the SQS service when creating the queue or listing with `ListQueues`:
+
+```javascript
+// async
+const queue = await sqs.createQueue({ QueueName: 'my-queue' }).promise();
+const subscription = await sns.subscribe({
+    TopicArn: myTopicArn,
+    Protocol: 'sqs',
+    Endpoint: queue.QueueUrl,
+}).promise();
 ```
 
 ## Contributors

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,9 +218,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.232.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.232.1.tgz",
-      "integrity": "sha1-e/4Y30xYHnldhPUe4uxKFunVZ4M=",
+      "version": "2.233.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.233.1.tgz",
+      "integrity": "sha1-tPVBBpqfJ4Hp9z4TNs6BqfwIvPE=",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/mj1618/serverless-offline-sns#readme",
   "dependencies": {
-    "aws-sdk": "^2.41.0",
+    "aws-sdk": "^2.233.1",
     "body-parser": "^1.18.2",
     "express": "^4.15.4",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This PR modifies the publishing functionality to add support for SQS subscriptions. It now checks the `Prototcol` property of the subscription, defaults to `http` if it was not set, and will now throw an error if the value is not one of `http` or `sqs` (case insensitive).

`http` subscriptions use the existing functionality with `fetch`. `sqs` subscriptions will instantiate an instance of the `aws-sdk` `SQS` client, using the protocol and host of the subscription's `Endpoint` as the `SQS` client endpoint, and the full URL of the subscription's `Endpoint` as the `QueueUrl`. As noted in the README, it is expected that the subscription is created using the full `QueueUrl` provided by SQS when creating the queue, or from `ListQueues` as the subscription endpoint.

I'm open to suggestions, but I couldn't see an easy way to unit test this without drastically changing the structure of the class. That said, I did test this locally against an instance of [elasticmq](https://github.com/adamw/elasticmq) and was able to subscribe and receive the SNS notifications as messages.