### PR TITLE
Allow for the handler file location to be provided by a CLI option.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,8 +63,9 @@ class ServerlessOfflineSns {
         this.accountId = this.config.accountId || "123456789012";
         const offlineConfig = this.serverless.service.custom["serverless-offline"] || {};
         this.location = process.cwd();
-        if (offlineConfig.location) {
-            this.location = process.cwd() + "/" + offlineConfig.location;
+        const locationRelativeToCwd = this.options.location || offlineConfig.location;
+        if (locationRelativeToCwd) {
+            this.location = process.cwd() + "/" + locationRelativeToCwd;
         } else if (this.serverless.config.servicePath) {
             this.location = this.serverless.config.servicePath;
         }


### PR DESCRIPTION
Currently, you can provide a location to the handler file folder relative to the current working directory using a [serverless-offline configuration value](https://github.com/mj1618/serverless-offline-sns/blob/master/src/index.ts#L66). However, serverless-offline also has a command-line option that this plugin isn't recognizing:

`--location              -l  The root location of the handlers' files. Defaults to the current directory`

This pull request fixes this, preferring the command-line option if one is provided.