### PR TITLE
handling use case where async lambda does not implement optional call…

### DIFF
--- a/test/mock/handler.ts
+++ b/test/mock/handler.ts
@@ -23,3 +23,9 @@ export const pseudoHandler = (evt, ctx, cb) => {
     setResult(evt.Records[0].Sns.TopicArn);
     cb("{}");
 };
+
+export const asyncHandler = async (evt, ctx) => {
+    await new Promise(res => setTimeout(res, 100));
+    setResult(evt.Records[0].Sns.TopicArn);
+    return "{}"
+};

--- a/test/mock/mock.state.ts
+++ b/test/mock/mock.state.ts
@@ -1,10 +1,16 @@
 let nPongs = 0;
 let event;
-let result = "";
+let _resolve;
+let _deferred;
 
-export const resetResult = () => result = "";
-export const getResult = () => result;
-export const setResult = value => result = value;
+export const resetResult = () =>
+    _deferred = new Promise(res =>
+        _resolve = (result) => res(result)
+    )
+export const getResult = () => _deferred;
+export const setResult = value => {
+    _resolve(value)
+};
 export const getPongs = () => nPongs;
 export const setPongs = value => nPongs = value;
 export const getEvent = () => event;


### PR DESCRIPTION
…back parameter.

This fixes a bug when using localstack for SNS where the sns publish will "hang" and localstack will throw `Connection Aborted' errors because the optional callback is never invoked, which finishes the request.

fixes #49 