### PR TITLE
Fix logging of topicName before creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,11 +146,11 @@ class ServerlessOfflineSns {
         const fn = this.serverless.service.functions[fnName];
 
         if (typeof snsConfig === "string" || typeof snsConfig.topicName === "string") {
-            this.log(`Creating topic: "${snsConfig}" for fn "${fnName}"`);
             let topicName = snsConfig;
             if (snsConfig.topicName && typeof snsConfig.topicName === "string") {
                 topicName = snsConfig.topicName;
             }
+            this.log(`Creating topic: "${topicName}" for fn "${fnName}"`);
             const data = await this.snsAdapter.createTopic(topicName);
             this.debug("topic: " + JSON.stringify(data));
             await this.snsAdapter.subscribe(fn, () => this.createHandler(fn), data.TopicArn);


### PR DESCRIPTION
## Given

```yaml
mySnsFn:
    handler: src/path/to/index.handler
    memorySize: 1024
    timeout: 120
    events:
      - sns:
          arn:
            Ref: MySnsTopicName
          topicName: my-sns-topic
```

## Before

```
Serverless: INFO[serverless-offline-sns]: Creating topic: "[object Object]" for fn "mySnsFn"
```

## After

```
Serverless: INFO[serverless-offline-sns]: Creating topic: "my-sns-topic" for fn "mySnsFn"
```