### PR TITLE
check for proper sns configuration if configured with string only

### DIFF
--- a/test/spec/sns.ts
+++ b/test/spec/sns.ts
@@ -220,7 +220,7 @@ const createServerless = (accountId: number, handlerName: string = "pongHandler"
                 pong: {
                     handler: "test/mock/handler." + handlerName,
                     events: [{
-                        sns: "test-topic",
+                        sns: `arn:aws:sns:us-east-1:${accountId}:test-topic`,
                     }],
                 },
                 pong2: {
@@ -298,7 +298,7 @@ const createServerlessCacheInvalidation = (accountId: number, handlerName: strin
                 pong: {
                     handler: "test/mock/handler." + handlerName,
                     events: [{
-                        sns: "test-topic",
+                        sns: `arn:aws:sns:us-west-2:${accountId}:test-topic`,
                     }],
                 },
             },
@@ -337,7 +337,7 @@ const createServerlessMultiDot = (accountId: number, handlerName: string = "pong
                 multiDot: {
                     handler: "test/mock/multi.dot.handler.itsGotDots",
                     events: [{
-                        sns: `multi-dot-topic`,
+                        sns: `arn:aws:sns:us-west-2:${accountId}:multi-dot-topic`,
                     }],
                 },
             },


### PR DESCRIPTION
this checks for the proper configuration of sns if only a string is given:

```
...
events
  - sns: arn:aws:sns:<region>:<AccountId>:<topic-name>
```

As documented by Serverless here:
https://serverless.com/framework/docs/providers/aws/events/sns/

this fixes an issue mentioned in issue #26 