### PR TITLE
fix(#30): Remove 120 sec default request timeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ class ServerlessOfflineSns {
                 this.debug(`listening on ${host}:${this.port}`);
                 res();
             });
+            this.server.setTimeout(0);
         });
     }
 


### PR DESCRIPTION
Remove the timeout for the express server which defaults to 120 seconds. This caused some requests which took a long time to throw a "socket hang up" error. This should fix the type of errors seen in #30 