### PR TITLE
subject field should be Subject

### DIFF
--- a/src/sns-adapter.ts
+++ b/src/sns-adapter.ts
@@ -178,10 +178,11 @@ export class SNSAdapter implements ISNSAdapter {
         return topicArn.replace(awsRegex, this.accountId);
     }
 
-    public async publish(topicArn: string, message: string, type: string = "", messageAttributes: MessageAttributeMap = {}) {
+    public async publish(topicArn: string, message: string, type: string = "", messageAttributes: MessageAttributeMap = {}, subject: string = "") {
         topicArn = this.convertPseudoParams(topicArn);
         return await new Promise((resolve, reject) => this.sns.publish({
             Message: message,
+            Subject: subject,
             MessageStructure: type,
             TopicArn: topicArn,
             MessageAttributes: messageAttributes,

--- a/src/sns-server.ts
+++ b/src/sns-server.ts
@@ -75,7 +75,7 @@ export class SNSServer implements ISNSServer {
                     xml(
                         this.publish(
                             target,
-                            req.body.subject,
+                            req.body.Subject,
                             req.body.Message,
                             req.body.MessageStructure,
                             parseMessageAttributes(req.body),

--- a/test/spec/sns.ts
+++ b/test/spec/sns.ts
@@ -56,7 +56,7 @@ describe("test", () => {
         expect(state.getPongs()).to.eq(2);
     });
 
-    it("should send event with MessageAttributes", async () => {
+    it("should send event with MessageAttributes and subject", async () => {
         plugin = new ServerlessOfflineSns(createServerless(accountId), {skipCacheInvalidation: true});
         const snsAdapter = await plugin.start();
         await snsAdapter.publish(
@@ -66,10 +66,12 @@ describe("test", () => {
             {
                 with: { DataType: "String", StringValue: "attributes" },
             },
+            "subject"
         );
         await new Promise(res => setTimeout(res, 100));
         const event = state.getEvent();
         expect(event.Records[0].Sns).to.have.property("Message", "message with attributes");
+        expect(event.Records[0].Sns).to.have.property("Subject", "subject");
         expect(event.Records[0].Sns).to.have.deep.property(
             "MessageAttributes",
             {


### PR DESCRIPTION
A SNS publish can accept a Subject for other than Email notifications and it should appear in the Sns record as "Subject" field not "subject".