### PR TITLE
Use existing, not new, message id to pass to SNS Lambda event

### DIFF
--- a/src/sns-adapter.ts
+++ b/src/sns-adapter.ts
@@ -119,7 +119,7 @@ export class SNSAdapter implements ISNSAdapter {
             let event = req.body;
             if (req.is("text/plain") && req.get("x-amz-sns-rawdelivery") !== "true") {
                 const msg = event.MessageStructure === "json" ? JSON.parse(event.Message).default : event.Message;
-                event = createSnsLambdaEvent(event.TopicArn, "EXAMPLE", event.Subject || "", msg, createMessageId(), event.MessageAttributes || {});
+                event = createSnsLambdaEvent(event.TopicArn, "EXAMPLE", event.Subject || "", msg, event.MessageId || createMessageId(), event.MessageAttributes || {});
             }
 
             if (req.body.SubscribeURL) {


### PR DESCRIPTION
I noticed that when running serverless-offline-sns to call a Lambda event, the MessageId returned by sns.publish did not match the record.Sns.MessageId in the call to dispatch in the Lambda. This results in not being able to match up results between the call and its eventual response, which this simple patch fixes, and brings in line with how SNS works when run on AWS.