### PR TITLE
Fix defects.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,10 @@ class ServerlessOfflineSns {
     public async subscribe(fnName, snsConfig) {
         this.debug("subscribe: " + fnName);
         const fn = this.serverless.service.functions[fnName];
+        if (!fn.runtime) {
+            fn.runtime = this.serverless.service.provider.runtime;
+        }
+        
         let topicName = "";
 
         // https://serverless.com/framework/docs/providers/aws/events/sns#using-a-pre-existing-topic
@@ -182,7 +186,7 @@ class ServerlessOfflineSns {
         if (!fn.runtime || fn.runtime.startsWith("nodejs")) {
             return this.createJavascriptHandler(fn);
         } else {
-            return this.createProxyHandler(fnName, fn);
+            return () => this.createProxyHandler(fnName, fn);
         }
     }
 


### PR DESCRIPTION
This resolves two issues that I found when trying to use this with the dotnetcore3.1 runtime:

- Set default for function runtime if not set at the function level. This will set the runtime to what is defined at the provider level of he serverless configuration.
- Updated createProxyHandler to return a function that returns the function handler method. This is what I believe should resolve executing non nodeJS runtimes.

I tested this locally using my fork of serverless-offline (which adds .net core support, currently a PR on their repo).