### PR TITLE
Add support for custom location parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ custom:
     # host: 0.0.0.0 # Optional, defaults to 127.0.0.1 if not provided to serverless-offline
     # sns-endpoint: http://127.0.0.1:4567 # Optional. Only if you want to use a custom endpoint
     # accountId: 123456789012 # Optional
+    # location .build # Optional if the location of your handler.js is not in ./ (useful for typescript)
 ```
 
 In normal operation, the plugin will use the same *--host* option as provided to serverless-offline. The *host* parameter as shown above overrides this setting.

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ class ServerlessOfflineSns {
         this.accountId = this.config.accountId || "123456789012";
         const offlineConfig = this.serverless.service.custom["serverless-offline"] || {};
         this.location = process.cwd();
-        const locationRelativeToCwd = this.options.location || offlineConfig.location;
+        const locationRelativeToCwd = this.options.location || (this.config.location ||offlineConfig.location);
         if (locationRelativeToCwd) {
             this.location = process.cwd() + "/" + locationRelativeToCwd;
         } else if (this.serverless.config.servicePath) {


### PR DESCRIPTION
This is useful when using typescript and your .build/handler is not in the root directory.