### PR TITLE
Dont error on an empty resources block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ class ServerlessOfflineSns {
   }
 
   private getResourceSubscriptions(serverless) {
-    const resources = serverless.service.resources.Resources;
+    const resources = serverless.service.resources?.Resources;
     const subscriptions = [];
     if (!resources) return subscriptions;
     new Map(Object.entries(resources)).forEach((value, key) => {

--- a/test/spec/sns.ts
+++ b/test/spec/sns.ts
@@ -415,6 +415,15 @@ describe("test", () => {
     });
     AWSMock.restore("SQS", "sendMessage");
   });
+
+  it("should handle empty resource definition", async () => {
+    const serverless = createServerless(accountId);
+    serverless.service.resources = undefined;
+    plugin = new ServerlessOfflineSns(serverless, {
+      skipCacheInvalidation: true,
+    });
+    await plugin.start();
+  })
 });
 
 const createServerless = (


### PR DESCRIPTION
Hi! I noticed that startup fails if the resources block of serverless.yml is empty.

![image](https://user-images.githubusercontent.com/36460150/125361252-ea581880-e321-11eb-84e3-4bf26193abc7.png)

This seems to fix it rather than defining an empty resources block.

Let me know what you think, thanks.

 