### PR TITLE
Fix error when servicesDirectory is passed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ class ServerlessOfflineSns {
       for (const directory of shell.ls("-d", "*/")) {
         shell.cd(directory);
         const service = directory.split("/")[0];
-        const serverless = await loadServerlessConfig(shell.pwd(), this.debug);
+        const serverless = await loadServerlessConfig(shell.pwd().toString(), this.debug);
         this.debug("Processing subscriptions for ", service);
         this.debug("shell.pwd()", shell.pwd());
         this.debug("serverless functions", serverless.service.functions);


### PR DESCRIPTION
Hello,

Plugin throws an error when specifying `servicesDirectory`. This pull request fixes this problem by
* pass `string` instead of `String` into `loadServerlessConfig`
* actualize getting config from another service