### PR TITLE
fix: only push valid subscriptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,16 @@ class ServerlessOfflineSns {
       const topicArn = get(["Properties", "TopicArn", "Ref"], value);
       const topicName = get(["Properties", "TopicName"], resources[topicArn]);
       const fnName = this.getFunctionName(resourceName);
+
+      if(!topicName){
+        this.log(`${fnName} does not have a topic name, skipping`);
+        return;
+      }
+
+      if(!fnName){
+        this.log(`${topicName} does not have a function, skipping`);
+        return;
+      }
       subscriptions.push({
         fnName,
         options: {


### PR DESCRIPTION
We have a number of custom resources defined in our serverless config. They aren't used for functions (DLQs) or their topics aren't discoverable by SNS Offline.

This fix makes the subscribe more defensive (as it was in previous versions) and logs that it's skipping the resource.