### PR TITLE
Fix #134  0.76.0: SNS -> publish to subscribed SQS queue, "Records" assumption leads to lost message, empty array. #134

### DIFF
--- a/src/sns-server.ts
+++ b/src/sns-server.ts
@@ -299,29 +299,14 @@ export class SNSServer implements ISNSServer {
     const sqsEndpoint = `${subEndpointUrl.protocol}//${subEndpointUrl.host}/`;
     const sqs = new SQS({ endpoint: sqsEndpoint, region: this.region });
 
-    if (sub["Attributes"]["RawMessageDelivery"] === "true") {
-      return sqs
-        .sendMessage({
-          QueueUrl: sub.Endpoint,
-          MessageBody: event,
-          MessageAttributes: formatMessageAttributes(messageAttributes),
-          ...(messageGroupId && { MessageGroupId: messageGroupId }),
-        })
-        .promise();
-    } else {
-      const records = JSON.parse(event).Records ?? [];
-      const messagePromises = records.map((record) => {
-        return sqs
-          .sendMessage({
-            QueueUrl: sub.Endpoint,
-            MessageBody: JSON.stringify(record.Sns),
-            MessageAttributes: formatMessageAttributes(messageAttributes),
-            ...(messageGroupId && { MessageGroupId: messageGroupId }),
-          })
-          .promise();
-      });
-      return Promise.all(messagePromises);
-    }
+    return sqs
+      .sendMessage({
+        QueueUrl: sub.Endpoint,
+        MessageBody: event,
+        MessageAttributes: formatMessageAttributes(messageAttributes),
+        ...(messageGroupId && { MessageGroupId: messageGroupId }),
+      })
+      .promise();
   }
 
   public publish(


### PR DESCRIPTION

There is no need to check ` if (sub["Attributes"]["RawMessageDelivery"] === "true") ` inside `publishSqs`, this `RawMessageDelivery` check-process is already handled by `publish`.

The `event` object is what should be sent directly to an sqs endpoint.

This PR also works with serverless-offline-sqs plugin.