### PR TITLE
feat(config): added option to enable https for the subscribe endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Looking for a maintainer for this project, email me if you are interested.
 
 # serverless-offline-sns
+
 A serverless plugin to listen to offline SNS and call lambda fns with events.
 
 [![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
@@ -12,6 +13,7 @@ A serverless plugin to listen to offline SNS and call lambda fns with events.
 [![All Contributors](https://img.shields.io/badge/all_contributors-33-orange.svg?style=flat-square)](#contributors)
 
 ## Docs
+
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Configure](#configure)
@@ -29,11 +31,13 @@ If you'd rather use your own endpoint, e.g. from your AWS account or a [localsta
 ## Installation
 
 Install the plugin
+
 ```bash
 npm install serverless-offline-sns --save
 ```
 
 Let serverless know about the plugin
+
 ```YAML
 plugins:
   - serverless-offline-sns
@@ -66,9 +70,10 @@ serverless-offline-sns:
     accountId: ${self:provider.accountId}
 ```
 
-In normal operation, the plugin will use the same *--host* option as provided to serverless-offline. The *host* parameter as shown above overrides this setting.
+In normal operation, the plugin will use the same _--host_ option as provided to serverless-offline. The _host_ parameter as shown above overrides this setting.
 
 If you are using the [serverless-offline](https://github.com/dherault/serverless-offline) plugin serverless-offline-sns will start automatically. If you are not using this plugin you can run the following command instead:
+
 ```bash
 serverless offline-sns start
 ```
@@ -88,6 +93,7 @@ functions:
 ```
 
 Or you can use the exact ARN of the topic, in 2 ways:
+
 ```YAML
 functions:
   pong:
@@ -106,31 +112,39 @@ var sns = new AWS.SNS({
   endpoint: "http://127.0.0.1:4002",
   region: "us-east-1",
 });
-sns.publish({
-  Message: "{content: \"hello!\"}",
-  MessageStructure: "json",
-  TopicArn: "arn:aws:sns:us-east-1:123456789012:test-topic",
-}, () => {
-  console.log("ping");
-});
+sns.publish(
+  {
+    Message: '{content: "hello!"}',
+    MessageStructure: "json",
+    TopicArn: "arn:aws:sns:us-east-1:123456789012:test-topic",
+  },
+  () => {
+    console.log("ping");
+  }
+);
 ```
 
 Note the region that offline-sns will listen on is what is configured in your serverless.yml provider.
 
 ## Localstack docker configuration
+
 In order to listen to localstack SNS event, if localstack is started with docker, you need the following:
+
 ```YAML
 custom:
   serverless-offline-sns:
     host: 0.0.0.0 # Enable plugin to listen on every local address
     sns-subscribe-endpoint: 192.168.1.225 #Host ip address
     sns-endpoint: http://localhost:4575 # Default localstack sns endpoint
+    https: false # Enables HTTPS protocol for the sns-subscribe-endpoint
 ```
+
 What happens is that the container running localstack will execute a POST request to the plugin, but to reach outside the container, it needs to use the host ip address.
 
 ## Hosted AWS SNS configuration
 
 In order to listen to a hosted SNS on AWS, you need the following:
+
 ```YAML
 custom:
   serverless-offline-sns:
@@ -139,6 +153,7 @@ custom:
     host: 0.0.0.0
     sns-subscribe-endpoint: ${env:SNS_SUBSCRIBE_ENDPOINT}
     sns-endpoint: ${env:SNS_ENDPOINT}
+    https: true # Enables HTTPS protocol for the sns-subscribe-endpoint
 ```
 
 If you want to unsubscribe when you stop your server, then call `sls offline-sns cleanup` when the script exits.
@@ -146,6 +161,7 @@ If you want to unsubscribe when you stop your server, then call `sls offline-sns
 ## Multiple serverless services configuration
 
 If you have multiple serverless services, please specify a root directory:
+
 ```YAML
 custom:
   serverless-offline-sns:
@@ -159,6 +175,7 @@ The root directory must contain directories with serverless.yaml files inside.
 If you use [serverless-offline](https://github.com/dherault/serverless-offline) this plugin will start automatically.
 
 However if you don't use serverless-offline you can start this plugin manually with -
+
 ```bash
 serverless offline-sns start
 ```
@@ -173,12 +190,14 @@ the SQS service when creating the queue or listing with `ListQueues`:
 
 ```javascript
 // async
-const queue = await sqs.createQueue({ QueueName: 'my-queue' }).promise();
-const subscription = await sns.subscribe({
+const queue = await sqs.createQueue({ QueueName: "my-queue" }).promise();
+const subscription = await sns
+  .subscribe({
     TopicArn: myTopicArn,
-    Protocol: 'sqs',
+    Protocol: "sqs",
     Endpoint: queue.QueueUrl,
-}).promise();
+  })
+  .promise();
 ```
 
 ## Contributors

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "nyc ts-mocha \"test/**/*.ts\" --slow 300 -p src/tsconfig.json",
     "lint": "tslint -c tslint.json 'src/**/*'",
     "prepare": "yarn run lint && yarn test && yarn build",
-    "prettier": "npx prettier --write src test",
+    "prettier": "npx prettier --write src test README.md",
     "upgrade": "npx npm-check-updates -u"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,10 @@ class ServerlessOfflineSns {
     } else {
       this.region = "us-east-1";
     }
-    this.autoSubscribe = this.config.autoSubscribe === undefined ? true : this.config.autoSubscribe;
+    this.autoSubscribe =
+      this.config.autoSubscribe === undefined
+        ? true
+        : this.config.autoSubscribe;
     // Congure SNS client to be able to find us.
     AWS.config.sns = {
       endpoint: "http://127.0.0.1:" + this.localPort,
@@ -204,13 +207,16 @@ class ServerlessOfflineSns {
     await this.unsubscribeAll();
     this.debug("subscribing functions");
     const subscribePromises: Array<Promise<any>> = [];
-    if(this.autoSubscribe) {
+    if (this.autoSubscribe) {
       if (this.servicesDirectory) {
         shell.cd(this.servicesDirectory);
         for (const directory of shell.ls("-d", "*/")) {
           shell.cd(directory);
           const service = directory.split("/")[0];
-          const serverless = await loadServerlessConfig(shell.pwd().toString(), this.debug);
+          const serverless = await loadServerlessConfig(
+            shell.pwd().toString(),
+            this.debug
+          );
           this.debug("Processing subscriptions for ", service);
           this.debug("shell.pwd()", shell.pwd());
           this.debug("serverless functions", serverless.service.functions);
@@ -581,7 +587,8 @@ class ServerlessOfflineSns {
       this.serverless.service.provider.stage,
       this.accountId,
       this.config.host,
-      this.config["sns-subscribe-endpoint"]
+      this.config["sns-subscribe-endpoint"],
+      this.config["https"]
     );
   }
 }

--- a/src/sls-config-parser.ts
+++ b/src/sls-config-parser.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as Serverless from "serverless";
-import * as findConfigPath from 'serverless/lib/cli/resolve-configuration-path';
+import * as findConfigPath from "serverless/lib/cli/resolve-configuration-path";
 
 export async function loadServerlessConfig(cwd = process.cwd(), debug) {
   console.log("debug loadServerlessConfig", cwd);
@@ -10,8 +10,8 @@ export async function loadServerlessConfig(cwd = process.cwd(), debug) {
     cwd = path.dirname(cwd);
   }
 
-  const configurationPath = await findConfigPath({cwd});
-  const serverless = new Serverless({configurationPath});
+  const configurationPath = await findConfigPath({ cwd });
+  const serverless = new Serverless({ configurationPath });
   await serverless.init();
   return serverless;
 }

--- a/src/sns-adapter.ts
+++ b/src/sns-adapter.ts
@@ -34,7 +34,7 @@ export class SNSAdapter implements ISNSAdapter {
     accountId,
     host,
     subscribeEndpoint,
-    enableHttps
+    enableHttps = false
   ) {
     this.pluginDebug = debug;
     this.app = app;

--- a/src/sns-adapter.ts
+++ b/src/sns-adapter.ts
@@ -1,6 +1,8 @@
 import * as AWS from "aws-sdk";
 import {
-  ListSubscriptionsResponse, ListTopicsResponse, MessageAttributeMap
+  ListSubscriptionsResponse,
+  ListTopicsResponse,
+  MessageAttributeMap,
 } from "aws-sdk/clients/sns.d";
 import * as _ from "lodash";
 import fetch from "node-fetch";
@@ -31,7 +33,8 @@ export class SNSAdapter implements ISNSAdapter {
     stage,
     accountId,
     host,
-    subscribeEndpoint
+    subscribeEndpoint,
+    enableHttps
   ) {
     this.pluginDebug = debug;
     this.app = app;
@@ -39,7 +42,7 @@ export class SNSAdapter implements ISNSAdapter {
     this.stage = stage;
     this.adapterEndpoint = `http://${host || "127.0.0.1"}:${localPort}`;
     this.baseSubscribeEndpoint = subscribeEndpoint
-      ? `http://${subscribeEndpoint}:${remotePort}`
+      ? `${enableHttps ? "https" : "http"}://${subscribeEndpoint}:${remotePort}`
       : this.adapterEndpoint;
     this.endpoint = snsEndpoint || `http://127.0.0.1:${localPort}`;
     this.debug("using endpoint: " + this.endpoint);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -45,4 +45,3 @@ export interface IMessageAttribute {
   Type: string;
   Value: string;
 }
-

--- a/test/spec/sns.ts
+++ b/test/spec/sns.ts
@@ -457,8 +457,8 @@ describe("test", () => {
 const createServerless = (
   accountId: number,
   handlerName: string = "pongHandler",
-  host: string|null = null,
-  subscribeEndpoint: string|null = null
+  host: string | null = null,
+  subscribeEndpoint: string | null = null
 ) => {
   return {
     config: {

--- a/test/spec/sns.ts
+++ b/test/spec/sns.ts
@@ -182,6 +182,25 @@ describe("test", () => {
     });
   });
 
+  it("should use the custom subscribe endpoint for subscription urls with https", async () => {
+    plugin = new ServerlessOfflineSns(
+      createServerless(
+        accountId,
+        "pongHandler",
+        "0.0.0.0",
+        "anotherHost",
+        true
+      ),
+      { skipCacheInvalidation: true }
+    );
+    const snsAdapter = await plugin.start();
+    const response = await snsAdapter.listSubscriptions();
+
+    response.Subscriptions.forEach((sub) => {
+      expect(sub.Endpoint.startsWith("https://anotherHost:4002")).to.be.true;
+    });
+  });
+
   it("should unsubscribe", async () => {
     plugin = new ServerlessOfflineSns(createServerless(accountId), {
       skipCacheInvalidation: true,
@@ -458,7 +477,8 @@ const createServerless = (
   accountId: number,
   handlerName: string = "pongHandler",
   host: string | null = null,
-  subscribeEndpoint: string | null = null
+  subscribeEndpoint: string | null = null,
+  https: boolean = false
 ) => {
   return {
     config: {
@@ -473,6 +493,7 @@ const createServerless = (
           accountId: accountId,
           host: host,
           "sns-subscribe-endpoint": subscribeEndpoint,
+          https,
         },
       },
       provider: {
@@ -592,7 +613,7 @@ const createServerless = (
 const createServerlessCacheInvalidation = (
   accountId: number,
   handlerName: string = "pongHandler",
-  host: string = null
+  host: string | null = null
 ) => {
   return {
     config: {
@@ -639,7 +660,7 @@ const createServerlessCacheInvalidation = (
 const createServerlessMultiDot = (
   accountId: number,
   handlerName: string = "pongHandler",
-  host: string = null
+  host: string | null = null
 ) => {
   return {
     config: {
@@ -725,7 +746,7 @@ const createServerlessBad = (accountId: number) => {
 const createServerlessWithFilterPolicies = (
   accountId: number,
   handlerName: string = "pongHandler",
-  host: string = null,
+  host: string | null = null,
   subscribeEndpoint = null
 ) => {
   return {


### PR DESCRIPTION
Ran `yarn prettier` which formatted a lot of other files.

Main change is the addition of a https option for the subscribe endpoint.

This gives more flexibility to enable https if preferred.