### PR TITLE
#191 Now supporting default exported handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -511,7 +511,7 @@ class ServerlessOfflineSns {
     const handlerFnName = fn.handler.substring(handlerFnNameIndex + 1);
     const fullHandlerPath = resolve(location, handlerPath);
     const handlers = await import(`${url.pathToFileURL(fullHandlerPath)}.js`);
-    return handlers[handlerFnName];
+    return handlers[handlerFnName] || handlers.default[handlerFnName];
   }
 
   public log(msg, prefix = "INFO[serverless-offline-sns]: ") {

--- a/test/mock/handler.ts
+++ b/test/mock/handler.ts
@@ -29,3 +29,12 @@ export const asyncHandler = async (evt, ctx) => {
   setResult(evt.Records[0].Sns.TopicArn);
   return "{}";
 };
+
+const defaultExportHandler = (evt, ctx, cb) => {
+  nPongs += 1;
+  setPongs(nPongs);
+  setEvent(evt);
+  cb(null, "{}");
+};
+
+export default { defaultExportHandler };


### PR DESCRIPTION
- added a test case for default exported handlers
- introduced a fallback to use the default exported handler if the handler reference does not exist in the imported handler file (thank you @renejesusgv for bringing this to my attention)

Fixes: #191 