### PR TITLE
fix: pass queueName through CloudFormation resource subscriptions to enable SNS→SQS routing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ class ServerlessOfflineSns {
       if (attribute !== "Arn") return;
       if (type !== "AWS::SQS::Queue") return;
 
+      const queueName = get(["Properties", "QueueName"], resources[resourceName]);
       const filterPolicy = get(["Properties", "FilterPolicy"], value);
       const protocol = get(["Properties", "Protocol"], value);
       const rawMessageDelivery = get(
@@ -198,6 +199,7 @@ class ServerlessOfflineSns {
         options: {
           topicName,
           protocol,
+          queueName,
           rawMessageDelivery,
           filterPolicy,
         },
@@ -561,7 +563,8 @@ class ServerlessOfflineSns {
       this.serverless.service.provider.stage,
       this.accountId,
       this.config.host,
-      this.config["sns-subscribe-endpoint"]
+      this.config["sns-subscribe-endpoint"],
+      this.config["sqsEndpoint"]
     );
   }
 }


### PR DESCRIPTION
## Summary

- `getResourceSubscriptions` correctly discovered `AWS::SNS::Subscription` resources but never extracted `QueueName` from the target `AWS::SQS::Queue`, silently breaking the SNS→SQS→Lambda pipeline for CloudFormation-defined infrastructure
- Extracts `QueueName` and passes it through the full subscription pipeline; `publishSqs` now resolves the queue URL via `GetQueueUrlCommand` rather than using a hardcoded endpoint
- Adds `sqsEndpoint` as a config option for pointing the SQS client at a local emulator (e.g. ElasticMQ)

Resolves the underlying issues behind #135 and #173.

## Test plan

- [ ] Existing test suite passes (21/27, 6 pre-existing failures unrelated to this change)
- [ ] `should subscribe` — verifies `GetQueueUrlCommand` is called with the queue name, and `SendMessageCommand` uses the resolved URL
- [ ] `should handle messageGroupId` — same flow with `MessageGroupId` forwarded correctly
- [ ] `should use the custom host for subscription urls` — updated to filter HTTP-only subscriptions (SQS subscriptions correctly use a separate `sqsEndpoint`)

**Tested against:** Serverless Framework v4, Node 20, ElasticMQ as local SQS emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)