### PR TITLE
fix: correct package.json version to 0.78.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-sns",
-  "version": "0.0.0-development",
+  "version": "0.78.1",
   "description": "Serverless plugin to run a local SNS server and call lambdas with events notifications.",
   "exports": "./dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- Corrects `"version": "0.0.0-development"` to `"version": "0.78.1"` — the last published npm version (closes #239)

## Test plan

- [ ] Release workflow publishes correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)