### PR TITLE
ci: use GH_TOKEN to allow semantic-release to push back to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
     name: Release
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     permissions:
       contents: write
       issues: write
@@ -17,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -31,6 +33,6 @@ jobs:
         run: yarn build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

- Replace `GITHUB_TOKEN` with `GH_TOKEN` (fine-grained PAT) in the release workflow so `@semantic-release/git` can push the version bump and `CHANGELOG.md` commit directly to `main`, bypassing branch protection
- Add `workflow_dispatch` trigger for manual runs
- Add `skip ci` guard to prevent the release workflow re-triggering on the semantic-release commit

Closes #241

## Test plan

- [ ] Merge and verify the release workflow runs end-to-end without the `GH006: Protected branch update failed` error
- [ ] Confirm a `chore: release x.y.z [skip ci]` commit appears on `main` after a successful release

🤖 Generated with [Claude Code](https://claude.com/claude-code)