### PR TITLE
chore: revert partial release 0.78.2 commit (tag deleted, re-release pending)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-## [0.78.2](https://github.com/BANCS-Norway/serverless-offline-sns/compare/v0.78.1...v0.78.2) (2026-02-25)
-
-
-### Bug Fixes
-
-* correct package.json version to 0.78.1 (closes [#239](https://github.com/BANCS-Norway/serverless-offline-sns/issues/239)) ([1e684f8](https://github.com/BANCS-Norway/serverless-offline-sns/commit/1e684f83414d1db8f0f611552455814b45683830))
-* pass queueName through CloudFormation resource subscriptions to enable SNS→SQS routing ([#222](https://github.com/BANCS-Norway/serverless-offline-sns/issues/222)) ([7b4cbcc](https://github.com/BANCS-Norway/serverless-offline-sns/commit/7b4cbcc483a6e8be513364a23abe399f625d631a)), closes [#135](https://github.com/BANCS-Norway/serverless-offline-sns/issues/135) [#173](https://github.com/BANCS-Norway/serverless-offline-sns/issues/173)
-* set valid version placeholder and update repo URLs to BANCS-Norway ([edc7003](https://github.com/BANCS-Norway/serverless-offline-sns/commit/edc7003e5e4196d2258263fa655ede8bf9edc9cf)), closes [#236](https://github.com/BANCS-Norway/serverless-offline-sns/issues/236)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-sns",
-  "version": "0.78.2",
+  "version": "0.78.1",
   "description": "Serverless plugin to run a local SNS server and call lambdas with events notifications.",
   "exports": "./dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- The previous release run partially completed: `@semantic-release/git` pushed the version bump and CHANGELOG.md to main and created the `v0.78.2` tag, but the publish phase (npm + GitHub release) never ran
- This reverts the partial release commit and deletes the tag so semantic-release can run the full pipeline cleanly on the next merge

## Test plan

- [ ] Merge this PR → semantic-release triggers → v0.78.2 published to npm and GitHub Releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)