### PR TITLE
feat: support lambda SNS subscription protocol

### DIFF
--- a/src/sns-server.ts
+++ b/src/sns-server.ts
@@ -409,7 +409,7 @@ export class SNSServer implements ISNSServer {
             sub.Protocol = "http";
           }
           const protocol = sub.Protocol.toLowerCase();
-          if (protocol === "http") {
+          if (protocol === "http" || protocol === "lambda") {
             return this.publishHttp(event, sub, isRaw);
           }
           if (protocol === "sqs") {


### PR DESCRIPTION
## Summary

- Adds support for `Protocol: lambda` SNS subscriptions by routing them through the existing HTTP handler infrastructure
- The local Lambda endpoint is resolved automatically — no configuration required
- `InvokeCommand` (introduced in #210) is used under the hood via the already-registered express route

## Test plan

- [ ] Configure a Lambda function with a direct SNS subscription (`Protocol: lambda`) in `serverless.yml`
- [ ] Publish a message to the topic and verify the Lambda is invoked with the correct SNS event payload
- [ ] Verify existing `http` and `sqs` protocol subscriptions are unaffected

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)