### PR TITLE
ci: add dependabot.yml with chore commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` configuring Dependabot to use `chore` as the commit message prefix
- Fixes #254 — all open Dependabot PRs were permanently blocked because their titles didn't match the allowed types in `pr-title-check.yml`

## Post-merge

Comment `@dependabot recreate` on #216, #220, #221, and #253 to regenerate them with the correct `chore(deps):` prefix.

## Test plan

- [ ] PR title check passes on this PR
- [ ] After merge, recreate existing Dependabot PRs and verify their titles pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)